### PR TITLE
Added a default size for icons without variant & basic keyboard support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,51 @@
+---
+name: Bug report
+about: Create a report to help us improve the Icon Gallery component
+---
+
+<!--
+    Please note that your issue will be fixed much faster if you includes the exact reproduction steps and a demo.
+-->
+
+### Describe the bug
+
+(Write your answer here.)
+
+### Steps to reproduce
+
+(Write your steps here:)
+
+1.
+2.
+3.
+
+### Expected behavior
+
+(Write what you thought would happen.)
+
+### Actual behavior
+
+<!--
+    Did something go wrong?
+    Is something broken, or not behaving as you expected?
+    Please attach screenshots if possible! They are extremely helpful for diagnosing issues.
+-->
+
+(Write what happened. Please add screenshots!)
+
+### Reproducible demo
+
+<!--
+    Your bug will get fixed much faster if we can run your code. 
+    
+    There are two ways to do it:
+
+        * Create a new app and provide a link to your repo.
+        * Paste the link to your JSFiddle (https://jsfiddle.net/Luktwrdm/) or CodeSandbox (https://codesandbox.io/s/new)
+-->
+
+(Write a link to your reproducible demo)
+
+<!--
+    Thank you for reporting a problem!
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,38 @@
+---
+name: Feature request
+about: Suggest an idea for improving the Icon Gallery component
+---
+
+### Is your feature request related to a problem?
+
+<!--
+  Provide a clear and concise description of what the problem is.
+  For example, "I'm always frustrated when..."
+-->
+
+(Write your answer here.)
+
+### Describe the solution you'd like
+
+<!--
+  Provide a clear and concise description of what you want to happen.
+-->
+
+(Describe your proposed solution here.)
+
+### Describe alternatives you've considered
+
+<!--
+  Let us know about other solutions you've tried or researched.
+-->
+
+(Write your answer here.)
+
+### Additional context
+
+<!--
+  Is there anything else you can add about the feature request?
+  You might want to link to related issues here, if you haven't already.
+-->
+
+(Write your answer here.)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+Issue:
+
+## What I did
+
+## How to test
+
+- Does this need an update to the documentation?
+
+If your answer is yes to any of these, please make sure to include it in your PR.

--- a/src/icon-item.jsx
+++ b/src/icon-item.jsx
@@ -53,7 +53,7 @@ IconItem.propTypes = {
     /**
      * The icon size.
      */
-    size: number.isRequired,
+    size: number,
     /**
      * A custom value to copy to the clipboard when the variant is clicked.
      */
@@ -66,4 +66,8 @@ IconItem.propTypes = {
      * @ignore
      */
     children: any
+};
+
+IconItem.defaultProps = {
+    size: 32
 };

--- a/src/inner-icon.jsx
+++ b/src/inner-icon.jsx
@@ -12,6 +12,7 @@ const { className, styles } = css.resolve` /* stylelint-disable-line */
         align-items: center;
         width: 100%;
         height: 100%;
+        outline: none;
     }
 
     .copy {
@@ -35,15 +36,20 @@ const { className, styles } = css.resolve` /* stylelint-disable-line */
     }
 
     .copy-action {
-        display: flex;
-        justify-content: center;
-        align-items: center;
+        position: absolute;
         color: #FFF;
         font-weight: 500;
         font-size: .75rem;
         cursor: pointer;
         width: 100%;
         height: 100%;
+        background-color: transparent;
+        border: 0;
+        outline: none;
+    }
+
+    .copy-action::-moz-focus-inner {
+        border: 0;
     }
 
     .copy-succeeded {
@@ -62,9 +68,9 @@ const { className, styles } = css.resolve` /* stylelint-disable-line */
     }
 
     .copy-form {
+        position: absolute;
         opacity: 0.01;
         height: 0;
-        position: absolute;
         z-index: -1;
     }
 `;
@@ -100,6 +106,16 @@ export function InnerIcon({ icon, copyValue }) {
         }
     });
 
+    const onIconClick = () => {
+        copyToClipboard();
+    };
+
+    const onIconEnterKey = event => {
+        if (event.keyCode === 13) {
+            copyToClipboard();
+        }
+    };
+
     const copyToClipboard = () => {
         textAreaRef.current.select();
         document.execCommand("copy");
@@ -108,19 +124,30 @@ export function InnerIcon({ icon, copyValue }) {
     };
 
     return (
-        <div className={`${className} icon sbdocs sbdocs-ig-icon`}>
+        <div className={`${className} icon sbdocs sbdocs-ig-icon`} onKeyDown={onIconEnterKey} tabIndex={0}>
             {icon}
-            <div className={`${className} copy sbdocs sbdocs-ig-copy`} onClick={copyToClipboard}>
+            <div className={`${className} copy sbdocs sbdocs-ig-copy`} tabIndex={-1}>
                 {copyAnimation.map(({ item, props, key }) => {
                     if (item) {
                         return (
-                            <a.div style={props} className={`${className} copy-succeeded sbdocs sbdocs-ig-copy-succeeded`} key={key}>
-                                <CheckmarkIcon className={`${className} copy-checkmark sbdocs sbdocs-ig-copy-checkmark`} />
+                            <a.div style={props} className={`${className} copy-succeeded sbdocs sbdocs-ig-copy-succeeded`} key={key} tabIndex={-1}>
+                                <CheckmarkIcon className={`${className} copy-checkmark sbdocs sbdocs-ig-copy-checkmark`} tabIndex={-1} />
                             </a.div>
                         );
                     }
 
-                    return <a.div style={props} className={`${className} copy-action sbdocs sbdocs-ig-copy-action`} key={key}>Copy</a.div>;
+                    return (
+                        <a.button
+                            style={props}
+                            className={`${className} copy-action sbdocs sbdocs-ig-copy-action`}
+                            onClick={onIconClick}
+                            type="button"
+                            key={key}
+                            tabIndex={-1}
+                        >
+                            Copy
+                        </a.button>
+                    );
                 })}
             </div>
             <form className={`${className} copy-form`}>
@@ -128,6 +155,7 @@ export function InnerIcon({ icon, copyValue }) {
                     readOnly
                     ref={textAreaRef}
                     value={copyValue}
+                    tabIndex={-1}
                 />
             </form>
             {styles}

--- a/stories/usage.stories.mdx
+++ b/stories/usage.stories.mdx
@@ -202,22 +202,22 @@ Variants are optionnal, you can still use this component if your design system d
 <Preview>
     <Story name="no-variants">
         <IconGallery>
-            <IconGallery.Item name="add" size={32}>
+            <IconGallery.Item name="add">
                 <AddIcon />
             </IconGallery.Item>
-            <IconGallery.Item name="calendar" size={32}>
+            <IconGallery.Item name="calendar">
                 <CalendarIcon />
             </IconGallery.Item>
-            <IconGallery.Item name="check" size={32}>
+            <IconGallery.Item name="check">
                 <CheckIcon />
             </IconGallery.Item>
-            <IconGallery.Item name="arrow" size={24}>
-                <ArrowIcon24 />
+            <IconGallery.Item name="arrow">
+                <ArrowIcon />
             </IconGallery.Item>
             <IconGallery.Item name="circle" size={24}>
                 <CircleIcon24 />
             </IconGallery.Item>
-            <IconGallery.Item name="csv" size={32}>
+            <IconGallery.Item name="csv">
                 <CsvIcon />
             </IconGallery.Item>
         </IconGallery>


### PR DESCRIPTION
Issue: https://github.com/gsoft-inc/storybook-icon-gallery/issues/2 https://github.com/gsoft-inc/storybook-icon-gallery/issues/3

- Added a default size of 32 for icons without variants
- Added tabs navigation and on enter key press support
- Transformed the copy action html to a button instead of a div