### PR TITLE
Force content-box box-sizing for the copy container element

### DIFF
--- a/src/icon-gallery.jsx
+++ b/src/icon-gallery.jsx
@@ -7,7 +7,6 @@ import { IconVariants } from "./icon-variants";
 
 const styles = css` /* stylelint-disable-line */
     .icon-gallery {
-        box-sizing: border-box;
         display: flex;
         flex-wrap: wrap;
     }

--- a/src/inner-icon.jsx
+++ b/src/inner-icon.jsx
@@ -26,6 +26,7 @@ const { className, styles } = css.resolve` /* stylelint-disable-line */
         background-color: #0E1C3D;
         width: 100%;
         height: 100%;
+        box-sizing: content-box;
     }
 
     .icon:hover .copy,

--- a/stories/usage.stories.mdx
+++ b/stories/usage.stories.mdx
@@ -276,6 +276,21 @@ An icon gallery can have multiple lines. The component will try to squeeze as mu
     </Story>
 </Preview>
 
+<Story
+    name="box-sizing-override"
+    parameters={{
+        docs: {
+            disable: true
+        }
+    }}
+>
+    <div className="border-box">
+        <IconGallery>
+            {renderItem("add", AddIcon24, AddIcon)}
+        </IconGallery>
+    </div>
+</Story>
+
 
 
 

--- a/storybook/styles.css
+++ b/storybook/styles.css
@@ -6,6 +6,7 @@ body {
     font-size: 16px;
 }
 
+/* SB docs */
 .sbdocs,
 .sbdocs.sbdocs-content {
     font-family: Calibre, Arial, Helvetica, sans-serif !important;
@@ -48,4 +49,11 @@ details + details {
 
 .sbdocs.sbdocs-a {
     font-size: 1.125rem;
+}
+
+/* Utils */
+.border-box *,
+.border-box *::before,
+.border-box *::after {
+    box-sizing: border-box;
 }


### PR DESCRIPTION
Issue: https://github.com/gsoft-inc/storybook-icon-gallery/issues/5

## What I did

- Force content-box box-sizing for the copy container element
- Added a story to test the use case

## How to test

- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.
